### PR TITLE
feat: fork predictive back gesture patch

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/all/misc/interaction/gestures/PredictiveBackGesturePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/all/misc/interaction/gestures/PredictiveBackGesturePatch.kt
@@ -1,0 +1,29 @@
+/*
+ * Forked from:
+ * https://gitlab.com/ReVanced/revanced-patches/-/blob/main/patches/src/main/kotlin/app/revanced/patches/all/misc/interaction/gestures/PredictiveBackGesturePatch.kt
+ */
+ 
+package app.morphe.patches.all.misc.interaction.gestures
+
+import app.morphe.patcher.patch.resourcePatch
+
+@Suppress("unused")
+val predictiveBackGesturePatch = resourcePatch(
+    name = "Predictive back gesture",
+    description = "Enables the predictive back gesture introduced on Android 13.",
+    default = false
+) {
+    execute {
+        val flag = "android:enableOnBackInvokedCallback"
+            
+        document("AndroidManifest.xml").use { document ->
+            with(document.getElementsByTagName("application").item(0)) {
+                if (attributes.getNamedItem(flag) != null) return@with
+
+                document.createAttribute(flag)
+                    .apply { value = "true" }
+                    .let(attributes::setNamedItem)
+            }
+        }
+    }
+}


### PR DESCRIPTION
This patch enables the predictive back gesture feature for Android 13 by modifying the AndroidManifest.xml.

### Description

I still missed the universal predictive back gesture patch

Closes #

### Additional context

<!-- ADD ADDITIONAL CONTEXT HERE -->

N/A

### Test results

- [ ] Tested on both the **minimum** and **maximum** supported versions
- [ ] Tested on **experimental** supported versions (Optional)
