### PR TITLE
fix: stabilize Google Photos GmsCore support

### DIFF
--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/GmsCoreSupportPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/GmsCoreSupportPatch.java
@@ -60,10 +60,10 @@ public class GmsCoreSupportPatch {
      * @return If the current package name is the same as the original unpatched app.
      *         If `GmsCore support` was not included during patching, this returns true;
      */
-    public static boolean isPackageNameOriginal() {
+    public static boolean isPackageNameOriginal(Context context) {
         String originalPackageName = getOriginalPackageName();
         return originalPackageName == null
-                || originalPackageName.equals(Utils.getContext().getPackageName());
+                || originalPackageName.equals(context.getPackageName());
     }
 
     private static void open(String queryOrLink) {
@@ -126,7 +126,7 @@ public class GmsCoreSupportPatch {
             // Verify the user has not included GmsCore for a root installation.
             // GmsCore Support changes the package name, but with a mounted installation
             // all manifest changes are ignored and the original package name is used.
-            if (isPackageNameOriginal()) {
+            if (isPackageNameOriginal(context)) {
                 Logger.printInfo(() -> "App is mounted with root, but GmsCore patch was included");
                 // Cannot use localize text here, since the app will load resources
                 // from the unpatched app and all patch strings are missing.

--- a/patches/src/main/kotlin/app/morphe/patches/googlephotos/misc/login/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/googlephotos/misc/login/Fingerprints.kt
@@ -7,8 +7,49 @@ package app.morphe.patches.googlephotos.misc.login
 import app.morphe.patcher.Fingerprint
 import app.morphe.util.getReference
 import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.iface.ClassDef
+import com.android.tools.smali.dexlib2.iface.Method
+import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.iface.reference.StringReference
+
+private fun Method.referencesString(value: String) =
+    implementation?.instructions?.any {
+        it.getReference<StringReference>()?.string == value
+    } == true
+
+private fun Method.referencesStringContaining(value: String) =
+    implementation?.instructions?.any {
+        it.getReference<StringReference>()?.string?.contains(value) == true
+    } == true
+
+private fun Method.referencesMethod(returnType: String, parameters: List<String>? = null) =
+    implementation?.instructions?.any {
+        it.getReference<MethodReference>()?.let { ref ->
+            ref.returnType == returnType && (parameters == null || ref.parameterTypes.toList() == parameters)
+        } == true
+    } == true
+
+private fun Method.referencesVoidMethodWithSingleObjectParameter() =
+    implementation?.instructions?.any {
+        it.getReference<MethodReference>()?.let { ref ->
+            ref.returnType == "V" &&
+                ref.parameterTypes.size == 1 &&
+                ref.parameterTypes.first().startsWith("L")
+        } == true
+    } == true
+
+private fun Method.referencesIntLiteral(value: Int) =
+    implementation?.instructions?.any {
+        it is NarrowLiteralInstruction && it.narrowLiteral == value
+    } == true
+
+private fun ClassDef.hasMethodReferencingString(value: String) =
+    methods.any { it.referencesString(value) }
+
+private fun ClassDef.hasMethodReferencingStringContaining(value: String) =
+    methods.any { it.referencesStringContaining(value) }
 
 /**
  * Matches `aext.d()` — the AccountValidityMonitor method that enqueues `CheckAccountTask`
@@ -18,18 +59,16 @@ internal object AccountValidityMonitorCheckFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
     returnType = "V",
     parameters = listOf(),
-    custom = { method, _ ->
-        method.implementation?.instructions?.let { insns ->
-            insns.any {
+    custom = { method, classDef ->
+        classDef.hasMethodReferencingString("AccountValidityMonitor") &&
+            classDef.hasMethodReferencingString("com.google.android.apps.photos.login.AccountValidityMonitor.CheckAccountTask") &&
+            method.implementation?.instructions?.let { instructions ->
+                instructions.any {
                 it.getReference<FieldReference>()?.let { ref ->
-                    ref.definingClass == "Laexv;" && ref.name == "a" && ref.type == "I"
+                    ref.name == "a" && ref.type == "I"
                 } == true
-            } && insns.any {
-                it.getReference<MethodReference>()?.toString()?.contains(
-                    "AccountValidityMonitor\$CheckAccountTask"
-                ) == true
-            }
-        } ?: false
+            } && method.referencesVoidMethodWithSingleObjectParameter()
+        } == true
     },
 )
 
@@ -42,14 +81,12 @@ internal object FrictionlessEligibilityFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
     returnType = "Z",
     parameters = listOf(),
-    custom = { method, _ ->
-        method.implementation?.instructions?.let { insns ->
-            insns.any {
-                it.getReference<MethodReference>()?.toString() == "Lasgb;->b()Z"
-            } && insns.any {
-                it.getReference<MethodReference>()?.toString() == "Laexs;->o(I)V"
-            }
-        } ?: false
+    custom = { method, classDef ->
+        classDef.hasMethodReferencingStringContaining("maybeStartFrictionless") &&
+            classDef.hasMethodReferencingString("ProvideFrctAccountTask") &&
+            method.referencesMethod("Z", emptyList()) &&
+            method.referencesMethod("V", listOf("I")) &&
+            method.referencesIntLiteral(-1)
     },
 )
 

--- a/patches/src/main/kotlin/app/morphe/patches/googlephotos/misc/login/SelectedAccountPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/googlephotos/misc/login/SelectedAccountPatch.kt
@@ -6,8 +6,12 @@ package app.morphe.patches.googlephotos.misc.login
 
 import app.morphe.patches.shared.compat.AppCompatibilities
 import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
-import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.util.getReference
+import app.morphe.util.indexOfFirstInstructionOrThrow
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
 @Suppress("unused")
 val selectedAccountPatch = bytecodePatch(
@@ -23,14 +27,22 @@ val selectedAccountPatch = bytecodePatch(
             "return-void",
         )
 
-        // 2) Make the frictionless-login eligibility check always succeed.
-        FrictionlessEligibilityFingerprint.method.addInstructions(
-            0,
-            """
-                const/4 p0, 0x1
-                return p0
-            """,
-        )
+        // 2) Keep the frictionless eligibility result intact, but prevent the
+        //    MicroG failure path from clearing the selected account.
+        FrictionlessEligibilityFingerprint.method.apply {
+            val clearSelectedAccountIndex = indexOfFirstInstructionOrThrow {
+                getReference<MethodReference>()?.let { ref ->
+                    ref.name == "o" &&
+                        ref.returnType == "V" &&
+                        ref.parameterTypes.toList() == listOf("I")
+                } == true
+            }
+            val accountHandlerClass = getInstruction(clearSelectedAccountIndex)
+                .getReference<MethodReference>()!!
+                .definingClass
+
+            replaceInstruction(clearSelectedAccountIndex, "invoke-virtual {p0}, $accountHandlerClass->p()V")
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Stabilizes Google Photos GmsCore support by avoiding a null-context warning path and making the selected-account persistence fix less version-specific.

Fixes #27

## Changes

- Pass the current `Activity` context into `GmsCoreSupportPatch.isPackageNameOriginal(...)` instead of reading `Utils.getContext()`.
  - This avoids the GmsCore support log path where the shared context can still be null.
  - The mounted/root install guard still compares against the same runtime package name.

- Harden Google Photos `Fix selected account persistence` fingerprints.
  - Removes matches tied to specific obfuscated class names.
  - Matches the account validity monitor through stable Photos strings and method behavior.
  - Matches the frictionless login fallback through stable task/log strings, method shape, and the `-1` fallback literal.

- Update the selected-account persistence behavior.
  - The earlier approach forced the frictionless login eligibility method to return `true`, which fixed persistence but could break first-launch initialization.
  - This version keeps the original eligibility result and only changes the MicroG failure path from clearing the selected account to selecting the default account.

## Testing

Tested patch application against:

- Google Photos 6.94.0
- Google Photos 7.17.0
- Google Photos 7.75.0

Installed patched Google Photos 7.75.0 with:

- `GmsCore support`
- `Spoof features`
- `Fix selected account persistence`

Runtime sanity check passed:

- app launches cleanly
- first launch can ask the user to select an account, as expected
- signed-in state persists after account selection
- backup state is visible
- background/restore no longer drops the signed-in state